### PR TITLE
Integrated newest good-console formatters + major api changes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -11,3 +11,38 @@ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
 WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+                                  *   *   *
+
+This codebase is based on good-console with the following Copyright license -
+
+Copyright (c) 2012-2014, Walmart and other contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * The names of any contributors may not be used to endorse or promote
+      products derived from this software without specific prior written
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+                                  *   *   *
+
+The complete list of contributors can be found at:
+	https://github.com/hapijs/good-winston/graphs/contributors
+	https://github.com/hapijs/good-console/graphs/contributors

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,122 +1,218 @@
 /*jshint laxcomma: true, smarttabs: true, node:true, esnext:true*/
 'use strict';
-const stream        = require('stream');
-const util          = require('util');
+const Moment        = require('moment');
 const Hoek          = require('hoek');
+const stream        = require('stream');
 const SafeStringify = require('json-stringify-safe');
 
-const LOG      = 'log';
-const REQUEST  = 'request';
-const RESPONSE = 'response';
-const ERROR    = 'error';
-const OPS      = 'ops';
-
-
 const internals = {
-  defaults: {
-    error_level: 'error',
-    ops_level: 'info',
-    request_level: 'info',
-    response_level: 'info',
-    other_level: 'info',
-    color: true
-  }
+    defaults: {
+        format: 'YYMMDD/HHmmss.SSS',
+        utc: true,
+        color: true,
+        level: {
+            other: 'info',
+            error: 'error',
+            ops: 'info',
+            //if unset log level will be parsed from the first tag as any other App level log
+            request: undefined,
+            response: 'info'
+        }
+    }
 };
 
-const methodColors = {
-    get: 32,
-    delete: 31,
-    put: 36,
-    post: 33,
-    patch:35
+internals.utility = {
+    formatOutput(event, settings) {
+
+        let timestamp = Moment(parseInt(event.timestamp, 10));
+
+        if (settings.utc) {
+            timestamp = timestamp.utc();
+        }
+
+        timestamp = timestamp.format(settings.format);
+
+        event.tags = event.tags.toString();
+        const tags = ` [${event.tags}] `;
+
+        // add event id information if available, typically for 'request' events
+        const id = event.id ? ` (${event.id})` : '';
+
+        const output = `${timestamp},${id}${tags}${event.data}`;
+
+        return output + `\n`;
+    },
+
+    formatMethod(method, settings) {
+
+        const methodColors = {
+            get: 32,
+            delete: 31,
+            put: 36,
+            post: 33
+        };
+
+        let formattedMethod = method.toLowerCase();
+        if (settings.color) {
+            const color = methodColors[method.toLowerCase()] || 34;
+            formattedMethod = `\x1b[1;${color}m${formattedMethod}\x1b[0m`;
+        }
+
+        return formattedMethod;
+    },
+
+    formatStatusCode(statusCode, settings) {
+
+        let color;
+        if (statusCode && settings.color) {
+            color = 32;
+            if (statusCode >= 500) {
+                color = 31;
+            }
+            else if (statusCode >= 400) {
+                color = 33;
+            }
+            else if (statusCode >= 300) {
+                color = 36;
+            }
+
+            return `\x1b[${color}m${statusCode}\x1b[0m`;
+        }
+
+        return statusCode;
+    },
+
+    formatResponse(event, tags, settings) {
+
+        const query = event.query ? JSON.stringify(event.query) : '';
+        const method = internals.utility.formatMethod(event.method, settings);
+        const statusCode = internals.utility.formatStatusCode(event.statusCode, settings) || '';
+
+        // event, timestamp, id, instance, labels, method, path, query, responseTime,
+        // statusCode, pid, httpVersion, source, remoteAddress, userAgent, referer, log
+        // method, pid, error
+        const output = `${event.instance}: ${method} ${event.path} ${query} ${statusCode} (${event.responseTime}ms)`;
+
+        const response = {
+            timestamp: event.timestamp,
+            tags,
+            data: output
+        };
+
+        return internals.utility.formatOutput(response, settings);
+    },
+
+    formatOps(event, tags, settings) {
+
+        const memory = Math.round(event.proc.mem.rss / (1024 * 1024));
+        const output = `memory: ${memory}Mb, uptime (seconds): ${event.proc.uptime}, load: [${event.os.load}]`;
+
+        const ops = {
+            timestamp: event.timestamp,
+            tags,
+            data: output
+        };
+
+        return internals.utility.formatOutput(ops, settings);
+    },
+
+    formatError(event, tags, settings) {
+
+        const output = `message: ${event.error.message}, stack: ${event.error.stack}`;
+
+        const error = {
+            timestamp: event.timestamp,
+            tags,
+            data: output
+        };
+
+        return internals.utility.formatOutput(error, settings);
+    },
+
+    formatDefault(event, tags, settings) {
+
+        const data = typeof event.data === 'object' ? SafeStringify(event.data) : event.data;
+        const output = `data: ${data}`;
+
+        const defaults = {
+            timestamp: event.timestamp,
+            id: event.id,
+            tags,
+            data: output
+        };
+
+        return internals.utility.formatOutput(defaults, settings);
+    },
+
+    // finds the first tag that represent a log level or return other level
+    levelFromTags(tags, settings, levels) {
+        return tags.reduce((level, tag) =>  level || levels[tag] !== undefined && tag, false) || settings.level.other;
+    }
 };
-
-function formatMethod(method, color) {
-    let formattedMethod = method.toLowerCase();
-    if (color) {
-        const clr = methodColors[method.toLowerCase()] || 34;
-        formattedMethod = `\x1b[1;${clr}m${formattedMethod}\x1b[0m`;
-    }
-
-    return formattedMethod;
-}
-
-
-function formatStatusCode(statusCode, color) {
-    let clr;
-    if (statusCode && color) {
-        clr = 32;
-        if (statusCode >= 500) {
-            clr = 31;
-        }
-        else if (statusCode >= 400) {
-            clr = 33;
-        }
-        else if (statusCode >= 300) {
-            clr = 36;
-        }
-
-        return `\x1b[${clr}m${statusCode}\x1b[0m`;
-    }
-
-    return statusCode;
-}
 
 class GoodWinston  extends stream.Writable {
+    constructor(config) {
+        super({objectMode: true});
+        Hoek.assert(this.constructor === GoodWinston, 'GoodWinston must be created with new');
+        Hoek.assert(config && config.winston, 'winston logger must not be null');
 
-  constructor(winston, options) {
-    super({objectMode: true});
-    options = options || {};
-    Hoek.assert(this.constructor === GoodWinston, 'GoodWinston must be created with new');
-    Hoek.assert(winston, 'winston logger must not be null');
+        this._settings = Hoek.applyToDefaults(internals.defaults, config);
+        this.winston   = config.winston;
 
-    let settings        = Object.assign({}, internals.defaults, options);
-    this.winston        = winston;
-    this.error_level    = settings.error_level;
-    this.ops_level      = settings.ops_level;
-    this.request_level  = settings.request_level;
-    this.response_level = settings.response_level;
-    this.other_level    = settings.other_level;
-    this.color          = settings.color;
-  }
-
-  _stringifyObject(object, title) {
-    return  object && Object.keys(object).length ? `${title}: ${SafeStringify(object)}` : '';
-  }
-
-  _logResponse(event, tags) {
-    let query           = this._stringifyObject(event.query, 'query'),
-        requestPayload  = this._stringifyObject(event.requestPayload, 'request payload'),
-        responsePayload = this._stringifyObject(event.responsePayload, 'response payload');
-    tags = tags || [];
-
-    return this.winston[this.response_level](`[${tags}] ${event.instance}: ${formatMethod(event.method,this.color)} ${event.path} ${query} ${requestPayload} ${formatStatusCode(event.statusCode,this.color)} (${event.responseTime}ms) ${responsePayload}`);
-  }
-
-  _write(data, encoding, callback) {
-    switch(data.event){
-      case RESPONSE:
-      this._logResponse(data, data.tags);
-      break;
-      case OPS:
-      this.winston[this.ops_level](`memory: ${Math.round(data.proc.mem.rss / (1024 * 1024))}Mb, uptime (seconds): ${data.proc.uptime}, load: ${ data.os.load}`);
-      break;
-    case ERROR:
-      this.winston[this.error_level](`message: ${data.error.message}\n stack: ${data.error.stack}`);
-      break;
-    case LOG:
-    case REQUEST:
-      this.winston[this.request_level]('data: ' + (typeof data.data === 'object' ? SafeStringify(data.data) : data.data));
-      break;
-    default:
-      if( data.data ){
-        this.winston[this.other_level]('data: ' + (typeof data.data === 'object' ? SafeStringify(data.data) : data.data));
-      } else {
-        this.winston[this.other_level]('data: (none)');
-      }
+        Object.keys(this._settings.level).forEach(level => {
+            this._settings.level[level] && Hoek.assert(this.winston.levels[this._settings.level[level]] !== undefined, `Log level ${this._settings.level[level]}(${level}) is not defined in winston`);
+        });
     }
 
-    setImmediate(callback);
-  }
+    _write(data, encoding, callback) {
+        const eventName = data.event;
+        let formatter = internals.utility.formatDefault;
+        let tags = [];
+        let level;
+
+        if (Array.isArray(data.tags)) {
+            tags = data.tags.concat([]);
+        }
+        else if (data.tags) {
+            tags = [data.tags];
+        }
+
+        switch (eventName) {
+            case 'error':
+                formatter = internals.utility.formatError;
+                level = this._settings.level.error;
+                break;
+            case 'ops':
+                formatter = internals.utility.formatOps;
+                level = this._settings.level.ops;
+                break;
+            case 'response':
+                formatter = internals.utility.formatResponse;
+                level = this._settings.level.response;
+                break;
+            case 'request':
+                level = this._settings.level.request || internals.utility.levelFromTags(tags, this._settings, this.winston.levels);
+                break;
+        }
+
+        if (!level) {
+             if (data.data instanceof Error) {
+                data.error = data.data;
+                formatter = internals.utility.formatError;
+                level = this._settings.level.error;
+            } else {
+                if (!data.data) {
+                    data.data = '(none)';
+                }
+
+                level = internals.utility.levelFromTags(tags, this._settings, this.winston.levels);
+            }
+        }
+
+        tags.unshift(eventName);
+        this.winston.log(level, formatter(data, tags, this._settings));
+        setImmediate(callback);
+    }
 }
+
 module.exports = GoodWinston;

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {},
   "dependencies": {
     "hoek": "^4.1.0",
-    "json-stringify-safe": "^5.0.1"
+    "json-stringify-safe": "^5.0.1",
+    "moment": "^2.18.1"
   }
 }


### PR DESCRIPTION
I found that a lot of the formatting available for good console are missing from the current implementation so I assumed refreshing the code base and just ripping all the logic from good-console is probably better than manually noticing missing data.

But since changing the format so massively should probably be a major version I decided to add some API changes that might be useful -

- Tags will set log level (in request log If level is not set for request log level will be deduced from tags, if level cannot be deduced `other` level will be used) 
- Single config object including winston as parameter ( so no need to pass both logger and options to constructor) 
- config level is an object instead of using xxx_level

I also had to change the license to accommodate to the code taken from good-console. I'm pretty sure the previous code borrowed some methods from good-reporter but I couldn't find the attribution for it. Since MIT and ISC arellamost identical, it probably be nicer if this code will just use MIT license to match good-console but since its not for me to decide I just left both licenses in.